### PR TITLE
Removing PostBuild event

### DIFF
--- a/Maestro.csproj
+++ b/Maestro.csproj
@@ -174,7 +174,7 @@
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
-    <PostBuildEvent>scp -i C:\Users\cthompson\.ssh\id_rsa_sccmlab $(TargetDir)* labadmin@aadjoin-intunee.eastus.cloudapp.azure.com:C:\Users\cthompson\git\Maestro\bin\Debug\</PostBuildEvent>
+    <PostBuildEvent></PostBuildEvent>
   </PropertyGroup>
   <Import Project="packages\dnMerge.0.5.15\build\dnMerge.targets" Condition="Exists('packages\dnMerge.0.5.15\build\dnMerge.targets')" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">


### PR DESCRIPTION
There's a post build event that references a non-existent cert. I'm just removing it for now so I can complete the build.