### PR TITLE
PRT cookie parse fix

### DIFF
--- a/source/authentication/RequestAADRefreshToken.cs
+++ b/source/authentication/RequestAADRefreshToken.cs
@@ -124,7 +124,7 @@ namespace Maestro
                         if (c.Name == "x-ms-RefreshTokenCredential")
                         {
                             // This is the PRT cookie
-                            string parsedPrtCookie = c.Data.Split(';').FirstOrDefault(x => x.Contains("eyJh"));
+                            string parsedPrtCookie = c.Data.Split(';').FirstOrDefault(x => x.Contains("eyJ"));
                             Logger.Info($"Found PRT cookie: {parsedPrtCookie}");
                             PrtCookie prtCookie = new PrtCookie(parsedPrtCookie, database);
                             prtCookies.Add(prtCookie);


### PR DESCRIPTION
Fix for the PRT cookie parsing method. The base64 content always starts with "eyJ" but the fourth character may vary so it has been removed from the search pattern to prevent the error "_Unhandled exception while requesting PRT cookies from LSA:CloudAP: System.NullReferenceException: Object reference not set to an instance of an object_".